### PR TITLE
upgrade emsdk to resolve bazel errors

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,11 +1,10 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-# emsdk 2.0.31
 http_archive(
     name = "emsdk",
-    strip_prefix = "emsdk-3891e7b04bf8cbb3bc62758e9c575ae096a9a518/bazel",
-    url = "https://github.com/emscripten-core/emsdk/archive/3891e7b04bf8cbb3bc62758e9c575ae096a9a518.tar.gz",
-    sha256 = "d55e3c73fc4f8d1fecb7aabe548de86bdb55080fe6b12ce593d63b8bade54567",
+    sha256="d18d951f192bded1f7cb99f0d402663a2aa61db11d17f15a587ab22c37b0ee42",
+    strip_prefix="emsdk-71780a80de0d4d8772406ab34549c5a5e26d7e51/bazel" ,
+    url = "https://github.com/emscripten-core/emsdk/archive/71780a80de0d4d8772406ab34549c5a5e26d7e51.tar.gz",
 )
 
 load("@emsdk//:deps.bzl", emsdk_deps = "deps")


### PR DESCRIPTION
older versions of emsdk use bazel's deprecated `@bazel_tools//platforms`.  I was building with bazel 6.0.0, and saw the following error:

```
ERROR: /home/luxe/.cache/bazel/_bazel_luxe/6c3ed7ac03b8ae1460f5a3054cc0f872/external/bazel_tools/platforms/BUILD:19:6: in alias rule @bazel_tools//platforms:x86_64: Constraints from @bazel_tools//platforms have been removed. Please use constraints from @platforms repository embedded in Bazel, or preferably declare dependency on https://github.com/bazelbuild/platforms. See https://github.com/bazelbuild/bazel/issues/8622 for details.
ERROR: /home/luxe/.cache/bazel/_bazel_luxe/6c3ed7ac03b8ae1460f5a3054cc0f872/external/bazel_tools/platforms/BUILD:19:6: Analysis of target '@bazel_tools//platforms:x86_64' failed
ERROR: /home/luxe/Desktop/emscripten-bazel-hello-world/hello-world/javascript/BUILD:32:10: While resolving toolchains for target //hello-world/javascript:hello-world-wasm.js: invalid registered toolchain '@build_bazel_rules_nodejs//toolchains/node:node_darwin_amd64_toolchain':
```

The solution is to update the emsdk library.